### PR TITLE
Wrapping urls in shellescape.

### DIFF
--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -518,7 +518,7 @@ function! s:LoadTaskLink()
     if tid != ""
         let tid = matchstr(tid, "\\d\\+")
         let taskurl = substitute(g:todo_taskurl, "%s", tid, "")
-        call system(shellescape(g:todo_browser) . " " . taskurl)
+        call system(shellescape(g:todo_browser) . " " . shellescape(taskurl))
         echo "Loading Task"
     else
         echo "No Task ID found"
@@ -530,7 +530,7 @@ endfunction
 function! s:LoadLink()
     let url=matchstr(getline("."), "https\\?://\\S\\+")
     if url != ""
-        call system(shellescape(g:todo_browser) . " " . url)
+        call system(shellescape(g:todo_browser) . " " . shellescape(url))
         echo "Loading URL"
     else
         echo "No URL Found"


### PR DESCRIPTION
Our web based task system uses ampersands for
parameters and this wasn't coming across to the
browsers.
